### PR TITLE
build: Increase CCACHE efficiency:

### DIFF
--- a/docker/ceph/build-ceph.sh
+++ b/docker/ceph/build-ceph.sh
@@ -6,6 +6,12 @@ set -e
 
 rm -rf build
 
+# Tricks to improve CCACHE hit ratio
+export SOURCE_DATE_EPOCH=$(date -d 'today 00:00 UTC' +%s)
+export BUILD_DATE=$(date --utc --date=@${SOURCE_DATE_EPOCH} +%Y-%m-%d)
+export ARGS='-D ENABLE_GIT_VERSION=OFF'
+export CCACHE_SLOPPINESS="time_macros"
+
 ./do_cmake.sh
 
 cd build


### PR DESCRIPTION
- By modifying environment variables (hardcoding _TIME_, _DATE_ macros, and disabling Git commit version string)