### PR TITLE
Improve build-ceph

### DIFF
--- a/docker/ceph/build-ceph.sh
+++ b/docker/ceph/build-ceph.sh
@@ -4,7 +4,8 @@ set -e
 
 CEPH_DIR=/ceph
 
-$CEPH_DIR/install-deps.sh
+cd $CEPH_DIR
+./install-deps.sh
 
 rm -rf $CEPH_DIR/build
 

--- a/docker/ceph/build-ceph.sh
+++ b/docker/ceph/build-ceph.sh
@@ -2,24 +2,24 @@
 
 set -e
 
-./install-deps.sh
+CEPH_DIR=/ceph
 
-rm -rf build
+$CEPH_DIR/install-deps.sh
+
+rm -rf $CEPH_DIR/build
 
 # Tricks to improve CCACHE hit ratio
-export SOURCE_DATE_EPOCH=$(date -d 'today 00:00 UTC' +%s)
+export SOURCE_DATE_EPOCH=358228200
 export BUILD_DATE=$(date --utc --date=@${SOURCE_DATE_EPOCH} +%Y-%m-%d)
 export ARGS='-D ENABLE_GIT_VERSION=OFF'
 export CCACHE_SLOPPINESS="time_macros"
 
-./do_cmake.sh
+$CEPH_DIR/do_cmake.sh
 
-cd /ceph/src/pybind/mgr/dashboard/frontend
+rm -rf $CEPH_DIR/src/pybind/mgr/dashboard/frontend/node_modules
 
-rm -rf node_modules
+cd $CEPH_DIR/build
 
-cd /ceph/build
-
-ccache make -j $(nproc --ignore=2)
+make -j $(nproc --ignore=2)
 
 echo "Ceph successfully built!!!"

--- a/docker/ceph/build-ceph.sh
+++ b/docker/ceph/build-ceph.sh
@@ -9,13 +9,13 @@ cd $CEPH_DIR
 
 rm -rf $CEPH_DIR/build
 
+$CEPH_DIR/do_cmake.sh
+
 # Tricks to improve CCACHE hit ratio
 export SOURCE_DATE_EPOCH=358228200
 export BUILD_DATE=$(date --utc --date=@${SOURCE_DATE_EPOCH} +%Y-%m-%d)
 export ARGS='-D ENABLE_GIT_VERSION=OFF'
 export CCACHE_SLOPPINESS="time_macros"
-
-$CEPH_DIR/do_cmake.sh
 
 rm -rf $CEPH_DIR/src/pybind/mgr/dashboard/frontend/node_modules
 


### PR DESCRIPTION
- Set SOURCE_DATE_EPOCH to fixed date (post 1980 to fix issues with some libraries). This increases hit rates, as the previous setting was also valid for intra-day builds.
- Use absolute paths instead of relative, which causes issues when launching from directories other than Ceph base.
- Additionally, use `$CEPH_DIR` variable.
- Remove ccache from before make command as it's not necessary if cmake has worked fine.