### PR TITLE
now vstart expects to run on tty-enabled envs

### DIFF
--- a/docker-compose.templates.yml
+++ b/docker-compose.templates.yml
@@ -2,6 +2,7 @@ version: '2.2'
 
 services:
     ceph-base:
+        tty: true
         volumes:
             - ./docker/ceph:/docker:ro
         environment:


### PR DESCRIPTION
Due to changes in https://github.com/ceph/ceph/pull/30859/ (commit ceph/ceph@f12076fa6117159c78c1f001ca05e6519aa9b767), now vstart fails (`"/dev/tty: No such device or address"`) when run in a pseudo-tty or a tty-less environment (like default docker containers).