### PR TITLE
rgw: do not run rgw stuff if RGW=0

### DIFF
--- a/docker/ceph/start-ceph.sh
+++ b/docker/ceph/start-ceph.sh
@@ -53,7 +53,7 @@ echo 'vstart.sh completed!'
 "$CEPH_BIN"/ceph osd pool application enable rbd-pool rbd
 
 # Configure Object Gateway:
-if [ "$RGW" -gt 0 ]; then
+if [ "$RGW" -gt 0 || "$RGW_MULTISITE" == 1 ]; then
     /docker/set-rgw.sh
 fi
 

--- a/docker/ceph/start-ceph.sh
+++ b/docker/ceph/start-ceph.sh
@@ -53,7 +53,9 @@ echo 'vstart.sh completed!'
 "$CEPH_BIN"/ceph osd pool application enable rbd-pool rbd
 
 # Configure Object Gateway:
-/docker/set-rgw.sh
+if [ "$RGW" -gt 0 ]; then
+    /docker/set-rgw.sh
+fi
 
 # Enable prometheus module
 if [[ "$IS_FIRST_CLUSTER" == 1 ]]; then


### PR DESCRIPTION
Even with RGW=0 the following error was triggered:
```
ceph-rpm2            | failed to init zonegroup: (2) No such file or directory
```

Signed-off-by: Ernesto Puerta <epuertat@redhat.com>