### PR TITLE
Force update submodules

### DIFF
--- a/docker/ceph/build-ceph.sh
+++ b/docker/ceph/build-ceph.sh
@@ -13,6 +13,8 @@ fi
 readonly CEPH_DIR=/ceph
 
 cd $CEPH_DIR
+# ISSUE install-deps.sh can fail if submodule dirs contain stale data, so by --force'ing we wipe that out and avoid that error later
+git submodule update --init --recursive --force
 ./install-deps.sh
 
 rm -rf $CEPH_DIR/build


### PR DESCRIPTION
The error displayed:
```sh
+ git submodule update --init --recursive
error: The following untracked working tree files would be overwritten by checkout:
        archive/15.0.0-539-g191ab33faf/forward_incompat/pg_missing_item
	archive/15.0.0-539-g191ab33faf/forward_incompat/pg_missing_t
...
	archive/15.0.0-539-g191ab33faf/objects/ACLGrant/18fcf7995095b5a416fe3ed5808124b0
	archive/15.0.0-539-...g191ab33faf/objects/AuthTicket/ff1b18c5ed56ca9dfab7e780c26de973
	archi
Aborting
Unable to checkout 'c24e498b76e74a7d23ffe2e715abe38026bd627c' in submodule path 'ceph-object-corpus'
```