### PR TITLE
replace pre-created rbd pool `rbd-pool` with `rbd`

### DIFF
--- a/docker/ceph/start-ceph.sh
+++ b/docker/ceph/start-ceph.sh
@@ -46,8 +46,8 @@ cd /ceph/build
 echo 'vstart.sh completed!'
 
 # Create rbd pool:
-"$CEPH_BIN"/ceph osd pool create rbd-pool 8 8 replicated
-"$CEPH_BIN"/ceph osd pool application enable rbd-pool rbd
+"$CEPH_BIN"/ceph osd pool create rbd 8 8 replicated
+"$CEPH_BIN"/ceph osd pool application enable rbd rbd
 
 # Configure Object Gateway:
 if [[ "$RGW" -gt 0  ||  "$RGW_MULTISITE" == 1 ]]; then


### PR DESCRIPTION
Most examples use `rbd` as the name for the rbd pool