### PR TITLE
Add commit-msg hook for downstream

### DIFF
--- a/docker/ceph/ci/commit-msg.sh
+++ b/docker/ceph/ci/commit-msg.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "Running commit-msg hook...'
+
+readonly BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+if [[ "$BRANCH" == ceph-*-rhel-patches ]]; then
+    grep "^Resolves: rhbz#[0-9]\+" "$1" || {
+        echo >&2 Missing 'Resolves: rhbz#<bz_number>' in commit message
+        exit 1
+    }
+fi

--- a/docker/ceph/ci/commit-msg.sh
+++ b/docker/ceph/ci/commit-msg.sh
@@ -8,7 +8,7 @@ readonly BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 if [[ "$BRANCH" == ceph-*-rhel-patches ]]; then
     grep "^Resolves: rhbz#[0-9]\+" "$1" || {
-        echo >&2 "Missing 'Resolves: rhbz#<bz_number>' in commit message"
+        echo >&2 "Error: Missing 'Resolves: rhbz#<bz_number>' in commit message"
         exit 1
     }
 fi

--- a/docker/ceph/ci/commit-msg.sh
+++ b/docker/ceph/ci/commit-msg.sh
@@ -2,13 +2,13 @@
 
 set -e
 
-echo "Running commit-msg hook...'
+echo "Running commit-msg hook..."
 
 readonly BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 if [[ "$BRANCH" == ceph-*-rhel-patches ]]; then
     grep "^Resolves: rhbz#[0-9]\+" "$1" || {
-        echo >&2 Missing 'Resolves: rhbz#<bz_number>' in commit message
+        echo >&2 "Missing 'Resolves: rhbz#<bz_number>' in commit message"
         exit 1
     }
 fi


### PR DESCRIPTION
... to avoid unintentional omissions.

NOTE: This hook is not run with clean cherry-picks (as they internally run with the `-n` flag (http://git.661346.n2.nabble.com/cherry-pick-pre-commit-hook-td5815961.html). An alterantive is to alias 'cherry-pick' with `-n`, so the back-porter needs to:
```sh
# alias cherry-pick to include -n
> git config alias.cp cherry-pick -x -S -n

> git cherry-pick ... <SHA1>
# cherry-pick doesn't perform automatic commit
> git cherry-pick --continue
error: no cherry-pick or revert in progress
fatal: cherry-pick failed
```