### PR TITLE
Upgrade cmake

### DIFF
--- a/docker/ceph/Dockerfile
+++ b/docker/ceph/Dockerfile
@@ -4,6 +4,7 @@ ARG CENTOS_VERSION
 
 # Required in order for build-doc to run successfully:
 RUN pip3 install -U Cython==0.29.3
+RUN pip3 install -U cmake==3.20.2
 
 RUN dnf install -y ccache \
     && dnf clean packages


### PR DESCRIPTION
with `dnf` we can't get the minimum version to fix the following issue:
```bash
+ cmake -GNinja -DWITH_PYTHON3=3.6 -DWITH_CCACHE=ON -DBOOST_J=10 -D ENABLE_GIT_VERSION=OFF ..
cmake: symbol lookup error: cmake: undefined symbol: archive_write_add_filter_zstd

```
so we use `pip` in order to upgrade
Signed-off-by: Pere Diaz Bou <pdiazbou@redhat.com>