### PR TITLE
ensure latest libarchive version is installed

### DIFF
--- a/docker/ceph/Dockerfile
+++ b/docker/ceph/Dockerfile
@@ -5,7 +5,8 @@ ARG CENTOS_VERSION
 # Required in order for build-doc to run successfully:
 RUN pip3 install -U Cython==0.29.3
 
-RUN dnf install -y ccache \
+# @TODO: erase libarchive install when cmake 3.20.2 or above is available as system package
+RUN dnf install -y ccache libarchive\
     && dnf clean packages
 
 ARG VCS_BRANCH=master


### PR DESCRIPTION
with `dnf` we can't get the minimum version to fix the following issue:
```bash
+ cmake -GNinja -DWITH_PYTHON3=3.6 -DWITH_CCACHE=ON -DBOOST_J=10 -D ENABLE_GIT_VERSION=OFF ..
cmake: symbol lookup error: cmake: undefined symbol: archive_write_add_filter_zstd

```
so we install the latest needed libarchive version which doesn't come with the current cmake.

Whenever this version is added to centos we should remove this.
Signed-off-by: Pere Diaz Bou <pdiazbou@redhat.com>