### PR TITLE
mgr/dashboard: Add jsonnet dependency to Dockerfile and add grafonnet-check to the tox checks list

### DIFF
--- a/docker/ceph/centos/Dockerfile
+++ b/docker/ceph/centos/Dockerfile
@@ -4,7 +4,7 @@ ARG CENTOS_VERSION
 
 RUN dnf install -y epel-release \
     && dnf clean packages
-RUN dnf install -y bind-utils curl dnf dnf-plugins-core git hostname iputils jq lsof net-tools \
+RUN dnf install -y bind-utils curl dnf dnf-plugins-core git hostname iputils jq jsonnet lsof net-tools \
     python3-jinja2 python3-jsonpatch python3-pip util-linux which \
     && dnf clean packages
 


### PR DESCRIPTION
This PR intends to add the jsonnet dependency to the ceph-dev environment and add the grafonnet-checks to the tox checks list

Signed-off-by: Aashish Sharma <aasharma@redhat.com>