### PR TITLE
vstart: add --cephadm support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
             - REMOTE_DASHBOARD_URL
             - RGW
             - RGW_MULTISITE=${RGW_MULTISITE:-0}
+            - VSTART_CEPHADM
         cap_add:
             - ALL
         entrypoint: /docker/entrypoint.sh

--- a/docker/ceph/set-start-env.sh
+++ b/docker/ceph/set-start-env.sh
@@ -30,6 +30,19 @@ if [[ "$CEPH_DEBUG" == 1 ]]; then
     RGW_DEBUG='--debug-rgw=20 --debug-ms=1'
     VSTART_OPTIONS="$VSTART_OPTIONS -d"
 fi
+if [[ "$VSTART_CEPHADM" == 1 ]]; then
+    VSTART_OPTIONS+=" --cephadm"
+    if [[ ! -f "/root/.ssh/id_rsa" ]]; then
+        mkdir -p ~/.ssh
+        chmod 700 ~/.ssh
+        ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa -q -N ""
+    fi
+    if [[ ! -f "/root/.ssh/known_hosts" ]]; then
+        ssh-keygen -A
+    fi
+    dnf install -y openssh-server
+    /usr/sbin/sshd
+fi
 export RGW_DEBUG
 export VSTART_OPTIONS
 


### PR DESCRIPTION
Install openssh-server and create associated files.

You need to add this to your `.env`: 
```
VSTART_CEPHADM=1
```

It still fails with:
```
[conn=0] Preferred auth methods: publickey
[conn=0] Auth failed for user root
[conn=0] Connection failure: Permission denied
[conn=0] Uncaught exception
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/asyncssh/connection.py", line 829, in _reap_task
    task.result()
concurrent.futures._base.CancelledError
[conn=0] Aborting connection
```

Fixes:
Signed-off-by: Ernesto Puerta <epuertat@redhat.com>