### PR TITLE
add bc dependency to build ceph

### DIFF
--- a/docker/ceph/Dockerfile
+++ b/docker/ceph/Dockerfile
@@ -5,7 +5,7 @@ ARG CENTOS_VERSION
 # Required in order for build-doc to run successfully:
 RUN pip3 install -U Cython==0.29.3
 
-RUN dnf install -y ccache systemd-udev \
+RUN dnf install -y bc ccache systemd-udev \
     && dnf clean packages
 
 ARG VCS_BRANCH=master


### PR DESCRIPTION
When running `docker-compose run --rm ceph /docker/build-ceph.sh` bc is missing.

Signed-off-by: Pere Diaz Bou <pdiazbou@redhat.com>