### PR TITLE
centos-dep: change baseUrl to the vault.centos.org

### DIFF
--- a/docker/ceph/Dockerfile
+++ b/docker/ceph/Dockerfile
@@ -2,6 +2,10 @@ ARG CENTOS_VERSION=8
 FROM rhcsdashboard/ceph-base:centos${CENTOS_VERSION}
 ARG CENTOS_VERSION
 
+# Centos met EOL and the content of the CentOS 8 repos has been moved to vault.centos.org
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
 # Required in order for build-doc to run successfully:
 RUN pip3 install -U Cython==0.29.3
 

--- a/docker/ceph/centos/Dockerfile
+++ b/docker/ceph/centos/Dockerfile
@@ -2,6 +2,10 @@ ARG CENTOS_VERSION=8
 FROM centos:$CENTOS_VERSION as ceph-base
 ARG CENTOS_VERSION
 
+# Centos met EOL and the content of the CentOS 8 repos has been moved to vault.centos.org
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
 RUN dnf install -y epel-release \
     && dnf clean packages
 RUN dnf install -y bind-utils curl dnf dnf-plugins-core git golang-github-prometheus hostname \

--- a/docker/ceph/e2e/Dockerfile
+++ b/docker/ceph/e2e/Dockerfile
@@ -1,6 +1,10 @@
 ARG CENTOS_VERSION=8
 FROM centos:$CENTOS_VERSION
 
+# Centos met EOL and the content of the CentOS 8 repos has been moved to vault.centos.org
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
 RUN dnf install -y https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm \
     libXScrnSaver xorg-x11-server-Xvfb \
     && dnf clean all

--- a/docker/ceph/rpm/Dockerfile
+++ b/docker/ceph/rpm/Dockerfile
@@ -2,6 +2,10 @@ ARG CENTOS_VERSION=8
 FROM rhcsdashboard/ceph-base:centos${CENTOS_VERSION}
 ARG CENTOS_VERSION
 
+# Centos met EOL and the content of the CentOS 8 repos has been moved to vault.centos.org
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
 # Sepia provide missing dependencies until epel provide all dependencies.
 RUN dnf config-manager --add-repo http://apt-mirror.front.sepia.ceph.com/lab-extras/${CENTOS_VERSION}/
 RUN dnf config-manager --setopt gpgcheck=0 apt-mirror.front.sepia.ceph.com_lab-extras_${CENTOS_VERSION}_ --save


### PR DESCRIPTION
centos went eol on dec 31st and their contents got moved to
vault.centos.org on jan 31st.

Signed-off-by: Nizamudeen A <nia@redhat.com>