### PR TITLE
restart-dashboard: fail mgr instead of disable and enable dashboard

### DIFF
--- a/docker/ceph/restart-dashboard.sh
+++ b/docker/ceph/restart-dashboard.sh
@@ -4,5 +4,5 @@ set -e
 
 cd /ceph/build
 
-"$CEPH_BIN"/ceph mgr module disable dashboard
-"$CEPH_BIN"/ceph mgr module enable dashboard --force
+MGR_ID=$("$CEPH_BIN"/ceph mgr stat | awk -v FS='"active_name": ' 'NF>1{print $2}' | tr -d '",')
+"$CEPH_BIN"/ceph mgr fail "$MGR_ID"


### PR DESCRIPTION
Based on the idea given by Sebastian https://github.com/rhcs-dashboard/ceph-dev/issues/30

Closes https://github.com/rhcs-dashboard/ceph-dev/issues/30
Signed-off-by: Nizamudeen A <nia@redhat.com>