### PR TITLE
fix grafana and prometheus mounts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,7 @@ services:
             - grafana_data:/var/lib/grafana
             - ./docker/grafana/grafana.ini:/etc/grafana/grafana.ini:Z
             - ./docker/grafana/provisioning:/etc/grafana/provisioning:Z
-            - ${CEPH_REPO_DIR}/monitoring/grafana/dashboards:/etc/grafana/provisioning/dashboards/ceph:Z
+            - ${CEPH_REPO_DIR}/monitoring/ceph-mixin/dashboards_out:/etc/grafana/provisioning/dashboards/ceph:Z
         environment:
             - GF_SECURITY_ALLOW_EMBEDDING=true
 
@@ -115,7 +115,7 @@ services:
         ports: ['${PROMETHEUS_HOST_PORT:-9090}:9090']
         volumes:
             - ./docker/prometheus:/etc/prometheus:Z
-            - ${CEPH_REPO_DIR}/monitoring/prometheus/alerts:/etc/prometheus/alerts:Z
+            - ${CEPH_REPO_DIR}/monitoring/ceph-mixin/prometheus_alerts.yml:/etc/prometheus/ceph/ceph_default_alerts.yml:Z
 
     node-exporter:
         image: ${NODE_EXPORTER_IMAGE:-prom/node-exporter:v0.18.1}


### PR DESCRIPTION
Due to recent adoption of ceph-mixin the path for the grafana dashboards and prometheus alerts
needs to be updated in the mounts.

Dashboards are visible now:
![Screenshot from 2022-02-21 16-52-04](https://user-images.githubusercontent.com/23611106/154945835-547d5ac2-080e-4802-81df-bc850a6b5145.png)

Signed-off-by: Avan Thakkar <athakkar@redhat.com>