### PR TITLE
mgr/dashboard: add a script to install docker and docker-compose on Ubuntu Linux distro.

### DIFF
--- a/docker/scripts/install-docker-compose-ubuntu.sh
+++ b/docker/scripts/install-docker-compose-ubuntu.sh
@@ -1,0 +1,28 @@
+# Ask for the user password
+# Script only works if sudo caches the password for a few minutes
+sudo true
+
+# Install kernel extra's to enable docker aufs support
+# sudo apt-get -y install linux-image-extra-$(uname -r)
+
+# Add Docker PPA and install latest version
+# sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
+# sudo sh -c "echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list"
+# sudo apt-get update
+# sudo apt-get install lxc-docker -y
+
+# Alternatively you can use the official docker install script
+wget -qO- https://get.docker.com/ | sh
+
+# Install docker-compose
+COMPOSE_VERSION=`git ls-remote https://github.com/docker/compose | grep refs/tags | grep -oE "[0-9]+\.[0-9][0-9]+\.[0-9]+$" | sort --version-sort | tail -n 1`
+sudo sh -c "curl -L https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose"
+sudo chmod +x /usr/local/bin/docker-compose
+sudo sh -c "curl -L https://raw.githubusercontent.com/docker/compose/${COMPOSE_VERSION}/contrib/completion/bash/docker-compose > /etc/bash_completion.d/docker-compose"
+
+# Install docker-cleanup command
+cd /tmp
+git clone https://gist.github.com/76b450a0c986e576e98b.git
+cd 76b450a0c986e576e98b
+sudo mv docker-cleanup /usr/local/bin/docker-cleanup
+sudo chmod +x /usr/local/bin/docker-cleanup

--- a/docker/scripts/install-docker-compose-ubuntu.sh
+++ b/docker/scripts/install-docker-compose-ubuntu.sh
@@ -18,7 +18,15 @@ fi
 # sudo apt-get install lxc-docker -y
 
 # Alternatively you can use the official docker install script
-wget -qO- https://get.docker.com/ | sh
+# wget -qO- https://get.docker.com/ | sh
+
+# Install docker from ubuntu repository 
+sudo apt remove --yes docker docker-engine docker.io containerd runc || true
+sudo apt-get update
+sudo apt-get upgrade
+sudo apt install docker.io
+systemctl start docker
+systemctl enable docker
 
 # Install docker-compose
 readonly dockerComposeVersion='1.21.0'

--- a/docker/scripts/install-docker-compose-ubuntu.sh
+++ b/docker/scripts/install-docker-compose-ubuntu.sh
@@ -1,6 +1,12 @@
-# Ask for the user password
-# Script only works if sudo caches the password for a few minutes
-sudo true
+#!/bin/bash
+
+set -e 
+
+# check user privileges:
+if [ "$(whoami)" != 'root' ]; then
+    echo "Super-user privileges are required. Please execute it with 'sudo'."
+    exit 1
+fi
 
 # Install kernel extra's to enable docker aufs support
 # sudo apt-get -y install linux-image-extra-$(uname -r)
@@ -15,10 +21,13 @@ sudo true
 wget -qO- https://get.docker.com/ | sh
 
 # Install docker-compose
-COMPOSE_VERSION=`git ls-remote https://github.com/docker/compose | grep refs/tags | grep -oE "[0-9]+\.[0-9][0-9]+\.[0-9]+$" | sort --version-sort | tail -n 1`
-sudo sh -c "curl -L https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose"
-sudo chmod +x /usr/local/bin/docker-compose
-sudo sh -c "curl -L https://raw.githubusercontent.com/docker/compose/${COMPOSE_VERSION}/contrib/completion/bash/docker-compose > /etc/bash_completion.d/docker-compose"
+readonly dockerComposeVersion='1.21.0'
+
+curl -Ls "https://github.com/docker/compose/releases/download/$dockerComposeVersion/docker-compose-$(uname -s)-$(uname -m)" \
+    -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose
+
+echo "Docker successfully installed!!!!"
 
 # Install docker-cleanup command
 cd /tmp

--- a/docker/scripts/install-docker-compose-ubuntu.sh
+++ b/docker/scripts/install-docker-compose-ubuntu.sh
@@ -8,17 +8,6 @@ if [ "$(whoami)" != 'root' ]; then
     exit 1
 fi
 
-# Install kernel extra's to enable docker aufs support
-# sudo apt-get -y install linux-image-extra-$(uname -r)
-
-# Add Docker PPA and install latest version
-# sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
-# sudo sh -c "echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list"
-# sudo apt-get update
-# sudo apt-get install lxc-docker -y
-
-# Alternatively you can use the official docker install script
-# wget -qO- https://get.docker.com/ | sh
 
 # Install docker from ubuntu repository 
 sudo apt remove --yes docker docker-engine docker.io containerd runc || true


### PR DESCRIPTION
The script helps the ubuntu user to install docker and docker-compose by just running it. 

Signed-off-by: Seremba Patrick <pserembae@gmail.com>