### PR TITLE
Github actions: docker login: use --password-stdin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
       if: failure()
     - name: Push
       run: |
-        docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+        echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
         docker push docker.io/rhcsdashboard/ceph-base:${{ matrix.os }}
         docker logout
   build-ceph:
@@ -72,7 +72,7 @@ jobs:
       if: failure()
     - name: Push
       run: |
-        docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+        echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
         docker push docker.io/rhcsdashboard/${{ matrix.name }}:${{ matrix.branch }}
         docker logout
   build-ceph-e2e:
@@ -95,6 +95,6 @@ jobs:
       if: failure()
     - name: Push
       run: |
-        docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+        echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
         docker push docker.io/rhcsdashboard/ceph-e2e:${{ matrix.branch }}
         docker logout


### PR DESCRIPTION
Fix this security warning:
```
Run docker login -u *** -p ***
WARNING! Using -*** the CLI is insecure. Use --password-stdin.
WARNING! Your password will be stored unencrypted in /home/runner/.docker/config.json.
```

Signed-off-by: Alfonso Martínez <almartin@redhat.com>