### PR TITLE
Fixing Rook Ceph Common Issues link

### DIFF
--- a/deployment/rook/README.md
+++ b/deployment/rook/README.md
@@ -2,7 +2,7 @@
 
 ## Troubleshooting
 
-Check [Rook Ceph Common Issues](https://rook.io/docs/rook/master/ceph-common-issues.html).
+Check [Rook Ceph Common Issues](https://rook.github.io/docs/rook/latest/Troubleshooting/ceph-common-issues/).
 
 ## Minikube cluster
 


### PR DESCRIPTION
Updated README.md with the correct link for the `Rook Ceph Common Issues` page.