### PR TITLE
centos: update the metalink for fedora.repo

### DIFF
--- a/docker/ceph/fedora/fedora.repo
+++ b/docker/ceph/fedora/fedora.repo
@@ -1,5 +1,5 @@
 [fedora]
 name=Fedora $basearch
-metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=$basearch
+metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-32&arch=$basearch
 enabled=1
 gpgcheck=0


### PR DESCRIPTION
```
------
 > [18/27] RUN dnf install -y ditaa     && dnf clean packages:
4.780 Fedora x86_64                                    17 MB/s |  61 MB     00:03
24.31 Last metadata expiration check: 0:00:21 ago on Thu Sep  7 02:45:20 2023.
31.55 Error:
31.55  Problem: package ditaa-0.10-7.fc30.noarch from fedora requires batik, but none of the providers can be installed
31.55   - package batik-1.10-4.fc30.noarch from fedora requires mvn(org.apache.xmlgraphics:batik-css) = 1.10, but none of the providers can be installed
31.55   - conflicting requests
31.55   - package batik-css-1.10-4.fc30.noarch from fedora is filtered out by modular filtering
31.55 (try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```

The latest build runs where failed with the above runs and it looks like batik-css v1.10 which is required for dita-0.10-7 is filtered out by modular filtering and it requires fedora 32 (atleast that was the one that worked locally for me)