### PR TITLE
docker/scripts: add scripts to mock devices

### DIFF
--- a/docker/ceph/scripts/dummy_devices.json
+++ b/docker/ceph/scripts/dummy_devices.json
@@ -1,0 +1,214 @@
+{
+    "inventory": [
+      {
+        "name": "node-0",
+        "devices": [
+          {
+            "path": "/dev/nvme0n1",
+            "sys_api": {
+              "vendor": "CCC",
+              "model": "ccc",
+              "size": 274877906944,
+              "rotational": "0",
+              "human_readable_size": "256 GB"
+            },
+            "available": true,
+            "rejected_reasons": [],
+            "device_id": "CCC-ccc-node-0-nvme0n1"
+          },
+          {
+            "path": "/dev/sda",
+            "sys_api": {
+              "vendor": "AAA",
+              "model": "aaa",
+              "size": 4398046511104,
+              "rotational": "1",
+              "human_readable_size": "4096 GB"
+            },
+            "available": false,
+            "rejected_reasons": [],
+            "device_id": "AAA-aaa-node-0-sda"
+          },
+          {
+            "path": "/dev/sdb",
+            "sys_api": {
+              "vendor": "AAA",
+              "model": "aaa",
+              "size": 4398046511104,
+              "rotational": "1",
+              "human_readable_size": "4096 GB"
+            },
+            "available": true,
+            "rejected_reasons": [],
+            "device_id": "AAA-aaa-node-0-sdb"
+          },
+          {
+            "path": "/dev/sdc",
+            "sys_api": {
+              "vendor": "AAA",
+              "model": "aaa",
+              "size": 4398046511104,
+              "rotational": "1",
+              "human_readable_size": "4096 GB"
+            },
+            "available": true,
+            "rejected_reasons": [],
+            "device_id": "AAA-aaa-node-0-sdc"
+          },
+          {
+            "path": "/dev/sdd",
+            "sys_api": {
+              "vendor": "BBB",
+              "model": "bbb",
+              "size": 549755813888,
+              "rotational": "0",
+              "human_readable_size": "512 GB"
+            },
+            "available": true,
+            "rejected_reasons": [],
+            "device_id": "BBB-bbb-node-0-sdd"
+          }
+        ]
+      },
+      {
+        "name": "node-1",
+        "devices": [
+          {
+            "path": "/dev/nvme0n1",
+            "sys_api": {
+              "vendor": "CCC",
+              "model": "ccc",
+              "size": 274877906944,
+              "rotational": "0",
+              "human_readable_size": "256 GB"
+            },
+            "available": true,
+            "rejected_reasons": [],
+            "device_id": "CCC-ccc-node-1-nvme0n1"
+          },
+          {
+            "path": "/dev/sda",
+            "sys_api": {
+              "vendor": "AAA",
+              "model": "aaa",
+              "size": 4398046511104,
+              "rotational": "1",
+              "human_readable_size": "4096 GB"
+            },
+            "available": false,
+            "rejected_reasons": [],
+            "device_id": "AAA-aaa-node-1-sda"
+          },
+          {
+            "path": "/dev/sdb",
+            "sys_api": {
+              "vendor": "AAA",
+              "model": "aaa",
+              "size": 4398046511104,
+              "rotational": "1",
+              "human_readable_size": "4096 GB"
+            },
+            "available": true,
+            "rejected_reasons": [],
+            "device_id": "AAA-aaa-node-1-sdb"
+          },
+          {
+            "path": "/dev/sdc",
+            "sys_api": {
+              "vendor": "AAA",
+              "model": "aaa",
+              "size": 4398046511104,
+              "rotational": "1",
+              "human_readable_size": "4096 GB"
+            },
+            "available": true,
+            "rejected_reasons": [],
+            "device_id": "AAA-aaa-node-1-sdc"
+          },
+          {
+            "path": "/dev/sdd",
+            "sys_api": {
+              "vendor": "BBB",
+              "model": "bbb",
+              "size": 549755813888,
+              "rotational": "0",
+              "human_readable_size": "512 GB"
+            },
+            "available": true,
+            "rejected_reasons": [],
+            "device_id": "BBB-bbb-node-1-sdd"
+          }
+        ]
+      },
+      {
+        "name": "node-2",
+        "devices": [
+          {
+            "path": "/dev/nvme0n1",
+            "sys_api": {
+              "vendor": "CCC",
+              "model": "ccc",
+              "size": 274877906944,
+              "rotational": "0",
+              "human_readable_size": "256 GB"
+            },
+            "available": true,
+            "rejected_reasons": [],
+            "device_id": "CCC-ccc-node-2-nvme0n1"
+          },
+          {
+            "path": "/dev/sda",
+            "sys_api": {
+              "vendor": "AAA",
+              "model": "aaa",
+              "size": 4398046511104,
+              "rotational": "1",
+              "human_readable_size": "4096 GB"
+            },
+            "available": false,
+            "rejected_reasons": [],
+            "device_id": "AAA-aaa-node-2-sda"
+          },
+          {
+            "path": "/dev/sdb",
+            "sys_api": {
+              "vendor": "AAA",
+              "model": "aaa",
+              "size": 4398046511104,
+              "rotational": "1",
+              "human_readable_size": "4096 GB"
+            },
+            "available": true,
+            "rejected_reasons": [],
+            "device_id": "AAA-aaa-node-2-sdb"
+          },
+          {
+            "path": "/dev/sdc",
+            "sys_api": {
+              "vendor": "AAA",
+              "model": "aaa",
+              "size": 4398046511104,
+              "rotational": "1",
+              "human_readable_size": "4096 GB"
+            },
+            "available": true,
+            "rejected_reasons": [],
+            "device_id": "AAA-aaa-node-2-sdc"
+          },
+          {
+            "path": "/dev/sdd",
+            "sys_api": {
+              "vendor": "BBB",
+              "model": "bbb",
+              "size": 549755813888,
+              "rotational": "0",
+              "human_readable_size": "512 GB"
+            },
+            "available": true,
+            "rejected_reasons": [],
+            "device_id": "BBB-bbb-node-2-sdd"
+          }
+        ]
+      }
+    ]
+  }

--- a/docker/ceph/scripts/mock-devices.sh
+++ b/docker/ceph/scripts/mock-devices.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+"$CEPH_BIN"/ceph mgr module enable test_orchestrator
+"$CEPH_BIN"/ceph orch set backend test_orchestrator
+"$CEPH_BIN"/ceph test_orchestrator load_data -i /docker/scripts/dummy_devices.json


### PR DESCRIPTION
I got the reference from Kefu's old PR[1] so I though it could be useful in
ceph-dev environments for mocking the Physical disks page.

![image](https://github.com/rhcs-dashboard/ceph-dev/assets/71764184/3c4c7aae-9dd5-4890-b7b6-376b19351582)


[1] https://github.com/ceph/ceph/pull/30921