### PR TITLE
docker-compose: Disable ipv6 in docker-compose yaml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,7 +175,7 @@ volumes:
 networks:
     default:
         driver: bridge
-        enable_ipv6: true
+        enable_ipv6: false
         ipam:
             driver: default
             config:


### PR DESCRIPTION
Ipv6 in docker-compose is required to be manually enabled in docker-daemon. Disabling it for dev environment.

Fixes https://github.com/rhcs-dashboard/ceph-dev/issues/79