### PR TITLE
start-ceph: remove rbd pool init from start script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,3 +65,4 @@ MON=3
 NFS=0
 OSD=3
 RGW=1
+NVMEOF_GW= # pass the ip of nvmeof_gw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
             - PYTHONDONTWRITEBYTECODE=1
             - RGW
             - RGW_MULTISITE=${RGW_MULTISITE:-0}
+            - NVMEOF_GW=${NVMEOF_GW}
         cap_add:
             - ALL
         entrypoint: /docker/entrypoint.sh

--- a/docker/ceph/start-ceph.sh
+++ b/docker/ceph/start-ceph.sh
@@ -52,10 +52,6 @@ cd /ceph/build
 
 echo 'vstart.sh completed!'
 
-# Create rbd pool:
-"$CEPH_BIN"/ceph osd pool create rbd 8 8 replicated
-"$CEPH_BIN"/ceph osd pool application enable rbd rbd
-
 # Configure Object Gateway:
 if [[ "$RGW" -gt 0  ||  "$RGW_MULTISITE" == 1 ]]; then
     /docker/set-rgw.sh


### PR DESCRIPTION
AFTER https://github.com/ceph/ceph/pull/54781

because after this change: https://github.com/ceph/ceph/pull/54781/commits/733eaada773767dee28da0d4da0e2d6f471494f2 it'll be done in the vstart script itself. no need to duplicate

i am also adding NVMEOF_GW var to env file which can be used to provide the ip of nvmeof_gw.