### PR TITLE
fix: Add squid branch in builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,13 +34,6 @@ jobs:
       uses: actions/checkout@master
     - name: Build
       run: docker build -t docker.io/rhcsdashboard/ceph-base:${{ matrix.os }} -f docker/ceph/centos/Dockerfile ./docker/ceph
-#    - name: Google Chat Notification
-#      uses: Co-qn/google-chat-notification@b9227d9daa4638c9782a5bd16c4abb86268127a1
-#      with:
-#        name: Build
-#        url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
-#        status: ${{ job.status }}
-#      if: failure()
     - name: Push
       run: |
         echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
@@ -52,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [main, reef, quincy, pacific]
+        branch: [main, squid, reef, quincy, pacific]
         name: [ceph, ceph-rpm]
         include:
           - centos_version: 9
@@ -65,13 +58,6 @@ jobs:
       uses: actions/checkout@master
     - name: Build
       run: docker build -t docker.io/rhcsdashboard/${{ matrix.name }}:${{ matrix.branch }} -f docker/${{ matrix.dir }}/${{ matrix.branch_dir}}/Dockerfile ./docker/ceph --build-arg CEPH_RELEASE=${{ matrix.branch }} --build-arg VCS_BRANCH=${{ matrix.branch }} --build-arg CENTOS_VERSION=${{ matrix.centos_version }}
-    - name: Google Chat Notification
-      uses: Co-qn/google-chat-notification@b9227d9daa4638c9782a5bd16c4abb86268127a1
-      with:
-        name: Build
-        url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
-        status: ${{ job.status }}
-      if: failure()
     - name: Push
       run: |
         echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
@@ -82,19 +68,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [main, reef, quincy, pacific]
+        branch: [main, squid, reef, quincy, pacific]
     steps:
     - name: Checkout
       uses: actions/checkout@master
     - name: Build
       run: docker build -t docker.io/rhcsdashboard/ceph-e2e:${{ matrix.branch }} -f docker/ceph/e2e/Dockerfile ./docker/ceph --build-arg VCS_BRANCH=${{ matrix.branch }}
-    - name: Google Chat Notification
-      uses: Co-qn/google-chat-notification@b9227d9daa4638c9782a5bd16c4abb86268127a1
-      with:
-        name: Build
-        url: ${{ secrets.GOOGLE_CHAT_WEBHOOK }}
-        status: ${{ job.status }}
-      if: failure()
     - name: Push
       run: |
         echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin


### PR DESCRIPTION
Squid branch is missing in ceph-dev builds.
This PR adds that.

Also disables google chat notification as we no longer use google chat.