### PR TITLE
start-ceph: do rm -rf only when path exists

### DIFF
--- a/docker/ceph/ci/sanity-checks.sh
+++ b/docker/ceph/ci/sanity-checks.sh
@@ -191,7 +191,7 @@ setup_api_tests_env() {
 
     cd "$REPO_DIR"/build
 
-    rm -rf "$CEPH_CONF_PATH"/*
+    rm -rf "${CEPH_CONF_PATH:?}"/*
     rm -f vstart_runner.log
 
     # vstart_runner uses /ceph/build cluster path.

--- a/docker/ceph/start-ceph.sh
+++ b/docker/ceph/start-ceph.sh
@@ -45,7 +45,7 @@ if [[ -n "${DASHBOARD_URL}" ]]; then
     exit 0
 fi
 
-rm -rf "$CEPH_CONF_PATH"/*
+rm -rf "${CEPH_CONF_PATH:?}"/*
 
 cd /ceph/build
 ../src/vstart.sh ${VSTART_OPTIONS}


### PR DESCRIPTION
`start-ceph.sh` has a line to remove `rm -rf "$CEPH_CONF_PATH"/*` If someone run this script locally when he has root previllages, he could accidentally remove his `/` directory because `CEPH_CONF_PATH` will come empty and the command will become `rm -rf /*` which is like shooting yourself infinitely..