### PR TITLE
ceph-exporter: add support for launching the exporter daemon

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,7 @@ DASHBOARD_SSL=1
 DASHBOARD_URL=
 TEST_ORCHESTRATOR=1
 RGW_MULTISITE=0
+EXPORTER=1
 
 # set this to a downstream product
 # note: multiple builds are not supported

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
             - PYTHONDONTWRITEBYTECODE=1
             - RGW
             - RGW_MULTISITE=${RGW_MULTISITE:-0}
+            - EXPORTER=${EXPORTER:-0}
             - NVMEOF_GW=${NVMEOF_GW}
         cap_add:
             - ALL

--- a/docker/ceph/rpm/Dockerfile
+++ b/docker/ceph/rpm/Dockerfile
@@ -13,6 +13,7 @@ ARG CEPH_RELEASE=main
 COPY rpm/*.* /root/
 RUN /root/set-ceph-repo.sh
 RUN dnf install -y --nogpgcheck ceph-mds ceph-mgr-cephadm ceph-mgr-dashboard \
+    ceph-exporter \
     ceph-mgr-diskprediction-local \
     ceph-mon ceph-osd ceph-radosgw rbd-mirror \
     && dnf clean packages

--- a/docker/ceph/set-start-env.sh
+++ b/docker/ceph/set-start-env.sh
@@ -26,6 +26,11 @@ fi
 export RGW_DEBUG
 export VSTART_OPTIONS
 
+# Add --exporter to VSTART_OPTIONS if the exporter flag is set
+if [[ "$EXPORTER" == 1 ]]; then
+    VSTART_OPTIONS="$VSTART_OPTIONS --cephexporter"
+fi
+
 HTTP_PROTO='http'
 if [[ "$DASHBOARD_SSL" == 1 ]]; then
     HTTP_PROTO='https'

--- a/docker/prometheus/ceph-exporter-targets.yml
+++ b/docker/prometheus/ceph-exporter-targets.yml
@@ -1,0 +1,8 @@
+[
+    {
+        "targets": [ "ceph:9926" ],
+        "labels": {
+          cluster: "cluster1"
+        }
+    },
+]

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -19,6 +19,15 @@ scrape_configs:
     - source_labels: [__address__]
       target_label: cluster
       replacement: 'cluster1'
+  - job_name: 'ceph-exporter'
+    honor_labels: true
+    file_sd_configs:
+      - files:
+        - ceph-exporter-targets.yml
+    relabel_configs:
+    - source_labels: [__address__]
+      target_label: cluster
+      replacement: 'cluster1'
   - job_name: 'federate'
     scrape_interval: 15s
     honor_labels: true


### PR DESCRIPTION
This PR adds support for optionally launching the `ceph-exporter` daemon in the Ceph environment setup. A new `--exporter` command-line option is introduced to the `vstart.sh` script (https://github.com/ceph/ceph/pull/60623), allowing users to enable or disable the exporter daemon. The changes include:

1. `docker-compose.yml`:
   - Added a new environment variable `EXPORTER` with a default value of `0`. The variable can be set to `1` to enable the exporter.
   
2. `docker/ceph/rpm/Dockerfile`:
   - Included the installation of `ceph-exporter` in the Docker image by adding it to the `dnf install` command, ensuring that the exporter daemon is available in the container.

3. `docker/ceph/set-start-env.sh`:
   - Modified the script to check for the `EXPORTER` flag. If set to `1`, the `--exporter` option is added to the `VSTART_OPTIONS`, triggering the startup of the exporter daemon when the environment is initialized.

4. `docker/prometheus/ceph-exporter-targets.yml` (new file):
   - Added a new configuration file to define the `ceph-exporter` targets for Prometheus scraping.

5. `docker/prometheus/prometheus.yml`:
   - Configured Prometheus to scrape metrics from the `ceph-exporter` by adding a new job for the exporter and using the `ceph-exporter-targets.yml` file for the target configuration.
