### PR TITLE
Update keycloak version in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,7 +151,7 @@ services:
             - '--config.file=/etc/alertmanager/config.yml'
 
     keycloak:
-        image: ${KEYCLOAK_IMAGE:-jboss/keycloak:11.0.3}
+        image: ${KEYCLOAK_IMAGE:-quay.io/keycloak/keycloak:26.1}
         container_name: keycloak
         hostname: keycloak
         ports: ['${KEYCLOAK_HOST_HTTP_PORT:-8080}:8080', '${KEYCLOAK_HOST_HTTPS_PORT:-8443}:8443']


### PR DESCRIPTION
Updated the Keycloak image reference in the configuration. Previously, it was set to jboss/keycloak:11.0.3, which is no longer available. It has now been replaced with the correct and maintained version.

Fixes: https://github.com/rhcs-dashboard/ceph-dev/issues/90
Signed-off-by: Ankit Kumar <51ankitkp@gmail.com