### PR TITLE
(fix): fix run_tox command for py3

### DIFF
--- a/docker/ceph/ci/sanity-checks.sh
+++ b/docker/ceph/ci/sanity-checks.sh
@@ -116,7 +116,7 @@ run_tox() {
         if [[ "$(tox -l | grep cov | wc -l)" > 0 ]]; then  # Nautilus branch.
             TOX_ARGS="py3-run pytest $TOX_ARGS"
         else  # Master branch.
-            TOX_ARGS="py3 $TOX_ARGS"
+            TOX_ARGS="py3 -- $TOX_ARGS"
         fi
     fi
 


### PR DESCRIPTION
getting error on running backend tests:

```
docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_tox tests/test_host.py
Running Tox...
usage: tox [-h] [--colored {yes,no}] [--stderr-color {BLACK,BLUE,CYAN,GREEN,LIGHTBLACK_EX,LIGHTBLUE_EX,LIGHTCYAN_EX,LIGHTGREEN_EX,LIGHTMAGENTA_EX,LIGHTRED_EX,LIGHTWHITE_EX,LIGHTYELLOW_EX,MAGENTA,RED,RESET,WHITE,YELLOW}] [-v | -q]
           [--exit-and-dump-after seconds] [-c file] [--workdir dir] [--root dir] [--runner {virtualenv}] [--version] [--no-provision [REQ_JSON]] [--no-recreate-provision] [-r] [-x OVERRIDE]
           {run,r,run-parallel,p,depends,de,list,l,devenv,d,schema,config,c,quickstart,q,exec,e,legacy,le} ...
tox: error: unrecognized arguments: tests/test_host.py
hint: if you tried to pass arguments to a command use -- to separate them from tox ones

```