### PR TITLE
docker-compose: fix Python site packages path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ CEPH_PROXY_HOST_PORT=4200
 CEPH_HOST_PORT=11000
 # Optional: a custom build directory other than default one ($CEPH_REPO_DIR/build)
 CEPH_CUSTOM_BUILD_DIR=
+CEPH_PYTHON_VERSION=
 CEPH_E2E_IMAGE=rhcsdashboard/ceph-e2e:nautilus
 
 CEPH_CONTAINER_CPUS=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
         volumes:
             - ./docker/ceph:/docker:z
             - ${CEPH_REPO_DIR}:/ceph
-            - ${CEPH_REPO_DIR}/src/python-common/ceph:/usr/lib/python3.6/site-packages/ceph
+            - ${CEPH_REPO_DIR}/src/python-common/ceph:/usr/lib/python${CEPH_PYTHON_VERSION:-3.9}/site-packages/ceph
             - ${CEPH_CUSTOM_BUILD_DIR:-empty_volume}:/ceph/build.custom
             - ${HOST_CCACHE_DIR:-~/.ccache}:/root/.ccache
             - ${NPM_DIR:-~/.npm}:/root/.npm

--- a/docker/ceph/Dockerfile
+++ b/docker/ceph/Dockerfile
@@ -12,11 +12,21 @@ ARG VCS_BRANCH=main
 RUN curl -LsS https://raw.githubusercontent.com/ceph/ceph/"$VCS_BRANCH"/install-deps.sh \
     -o /ceph/install-deps.sh \
     && chmod +x /ceph/install-deps.sh
+RUN (curl -LsS https://raw.githubusercontent.com/ceph/ceph/"$VCS_BRANCH"/src/script/lib-build.sh \
+    -o /ceph/src/script/lib-build.sh --create-dirs \
+    && chmod +x /ceph/src/script/lib-build.sh ) || true
 RUN curl -LsS https://raw.githubusercontent.com/ceph/ceph/"$VCS_BRANCH"/ceph.spec.in \
     -o /ceph/ceph.spec.in
 
 ARG FOR_MAKE_CHECK=1
-ARG _SOURCED_LIB_BUILD=1
+ARG _SOURCED_LIB_BUILD=0
+# This is required in squid and reef.
+RUN if [[ "${VCS_BRANCH}" =~ ^(reef|squid)$ ]]; then \
+    dnf install -y --skip-broken \  
+        https://github.com/Seagate/cortx-motr/releases/download/2.0.0-rgw/isa-l-2.30.0-1.el7.x86_64.rpm \
+        https://github.com/Seagate/cortx-motr/releases/download/2.0.0-rgw/cortx-motr-2.0.0-1_git3252d623_any.el8.x86_64.rpm \
+        https://github.com/Seagate/cortx-motr/releases/download/2.0.0-rgw/cortx-motr-devel-2.0.0-1_git3252d623_any.el8.x86_64.rpm; \
+    fi
 RUN bash -x /ceph/install-deps.sh \
     && dnf clean packages
 

--- a/docker/ceph/centos/Dockerfile
+++ b/docker/ceph/centos/Dockerfile
@@ -57,7 +57,7 @@ RUN dnf install -y libtool-ltdl-devel libxml2-devel xmlsec1-devel xmlsec1-openss
     && dnf clean packages
 
 # SSO (after installing xmlsec deps).
-RUN pip3 install python3-saml==1.9.0
+RUN pip3 install python3-saml==1.16.0 --only-binary=:all:
 
 # NFS Ganesha.
 RUN dnf install -y centos-release-nfs-ganesha5 centos-release-ceph-reef \


### PR DESCRIPTION
Also reverts https://github.com/rhcs-dashboard/ceph-dev/pull/74.