### PR TITLE
fix xmlsec and tox errors

### DIFF
--- a/docker/ceph/centos/Dockerfile
+++ b/docker/ceph/centos/Dockerfile
@@ -18,7 +18,9 @@ RUN sed -i 's/skip_if_unavailable=False/skip_if_unavailable=True/' /etc/dnf/dnf.
 RUN pip3 install -U pip
 
 # Sanity checks:
-RUN pip3 install mypy tox
+# pinning tox to less than 4 since newer versions of it
+# is breaking it in py3.9
+RUN pip3 install mypy 'tox<4'
 
 # AWS CLI.
 RUN pip3 install awscli boto3 boto3-stubs
@@ -52,14 +54,6 @@ RUN dnf install -y ant doxygen libxslt-devel libxml2-devel graphviz python3-deve
 RUN pip3 uninstall -y virtualenv
 RUN pip3 install virtualenv
 
-# For dev. mode: run backend unit tests.
-RUN dnf install -y libtool-ltdl-devel libxml2-devel xmlsec1-devel xmlsec1-openssl-devel \
-    && dnf clean packages
-
-# SSO (after installing xmlsec deps).
-RUN pip3 install --no-binary=xmlsec,python3-saml xmlsec==1.3.9 python3-saml==1.16.0
-
-# NFS Ganesha.
 RUN dnf install -y centos-release-nfs-ganesha5 centos-release-ceph-reef \
     && dnf install -y libcephfs2 nfs-ganesha-ceph nfs-ganesha-rados-grace nfs-ganesha-rados-urls \
     && dnf clean packages

--- a/docker/ceph/centos/Dockerfile
+++ b/docker/ceph/centos/Dockerfile
@@ -57,7 +57,7 @@ RUN dnf install -y libtool-ltdl-devel libxml2-devel xmlsec1-devel xmlsec1-openss
     && dnf clean packages
 
 # SSO (after installing xmlsec deps).
-RUN pip3 install python3-saml==1.16.0 --only-binary=:all:
+RUN pip3 install --no-binary=xmlsec,python3-saml xmlsec==1.3.9 python3-saml==1.16.0
 
 # NFS Ganesha.
 RUN dnf install -y centos-release-nfs-ganesha5 centos-release-ceph-reef \

--- a/docker/ceph/rpm/Dockerfile
+++ b/docker/ceph/rpm/Dockerfile
@@ -7,6 +7,19 @@ RUN dnf config-manager --add-repo http://apt-mirror.front.sepia.ceph.com/lab-ext
 RUN dnf config-manager --setopt gpgcheck=0 apt-mirror.front.sepia.ceph.com_lab-extras_${CENTOS_VERSION}_ --save
 RUN dnf copr enable -y ceph/el${CENTOS_VERSION}
 
+ARG VCS_BRANCH=main
+RUN curl -LsS https://raw.githubusercontent.com/ceph/ceph/"$VCS_BRANCH"/install-deps.sh \
+    -o /ceph/install-deps.sh \
+    && chmod +x /ceph/install-deps.sh
+RUN (curl -LsS https://raw.githubusercontent.com/ceph/ceph/"$VCS_BRANCH"/src/script/lib-build.sh \
+    -o /ceph/src/script/lib-build.sh --create-dirs \
+    && chmod +x /ceph/src/script/lib-build.sh ) || true
+RUN curl -LsS https://raw.githubusercontent.com/ceph/ceph/"$VCS_BRANCH"/ceph.spec.in \
+    -o /ceph/ceph.spec.in
+
+RUN bash -x /ceph/install-deps.sh \
+    && dnf clean packages
+
 ARG USE_REPO_FILES=0
 ARG REPO_URL
 ARG CEPH_RELEASE=main


### PR DESCRIPTION
xmlsec error
```
when importing the saml in the dashboard, it fails with
```
xmlsec.InternalError: (-1, 'lxml & xmlsec libxml2 library version mismatch')
```
which prevents dashboard from starting. Trying to fix it with a pinned
version of xmlsec (because the newer one is failing to install in
centos9 because of the known binary wheels issue)
```

tox error
```
AttributeError: 'PythonSpec' object has no attribute 'free_threaded'
```