### PR TITLE
docker-compose: update the docker compose version

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,7 @@ DASHBOARD_URL=
 TEST_ORCHESTRATOR=1
 RGW_MULTISITE=0
 EXPORTER=1
+DASHBOARD_NPM_CI=0 # set to 1 to run `npm ci` instead of `npm install`
 
 # set this to a downstream product
 # note: multiple builds are not supported

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ cp .env.example .env
 * Install [Docker Compose](https://docs.docker.com/compose/install/) by running the following, depending on your OS:
 ```
 # Fedora:
-sudo bash ./docker/scripts/install-docker compose-fedora.sh
+sudo bash ./docker/scripts/install-docker-compose-fedora.sh
 
 # CentOS 7 / RHEL 7:
-sudo bash ./docker/scripts/install-docker compose-centos-rhel.sh
+sudo bash ./docker/scripts/install-docker-compose-centos-rhel.sh
 ```
 
 If you ran the above script, then you can run *docker* and *docker compose* without *sudo* if you log out and log in.

--- a/README.md
+++ b/README.md
@@ -13,25 +13,25 @@
     git clone https://github.com/rhcs-dashboard/ceph-dev.git
     ```
 1. Enter `ceph-dev` directory.
-1. To install `docker` and `docker-compose`, if you're using:
-   * Fedora: `sudo bash ./docker/scripts/install-docker-compose-fedora.sh`
-   * CentOS/RHEL: `sudo bash ./docker/scripts/install-docker-compose-centos-rhel.sh`
+1. To install `docker` and `docker compose`, if you're using:
+   * Fedora: `sudo bash ./docker/scripts/install-docker compose-fedora.sh`
+   * CentOS/RHEL: `sudo bash ./docker/scripts/install-docker compose-centos-rhel.sh`
    * Other OSes: please check [this](https://docs.docker.com/compose/install/). Additionally, please ensure that SELinux is running in permissive mode:
      ```bash
      setenforce 0
      sed -i -E 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
      ```
 1. Use `.env.example` template for ceph-dev configuration: `cp .env.example .env`, edit `.env` and modify `CEPH_REPO_DIR=/path/to/...` to point to the directory where you cloned the Ceph repo (step #1)
-1. Download the container images: `docker-compose pull`
+1. Download the container images: `docker compose pull`
 1. Launch it (for a minimal Ceph-only deployment):
     ```
-    docker-compose up -d ceph
+    docker compose up -d ceph
     ```
     or  (for Ceph + monitoring stack):
     ```
-    docker-compose up -d ceph grafana prometheus alertmanager node-exporter
+    docker compose up -d
     ```
-1. Check how things are going with `docker-compose logs -f ceph`:
+1. Check how things are going with `docker compose logs -f ceph`:
    * After a couple of minutes (aprox.) it'll finally print `All done`.
 1. The dashboard will be available at: `https://127.0.0.1:11000` with credentials: `admin / admin`.
 
@@ -56,22 +56,22 @@ cp .env.example .env
 * Install [Docker Compose](https://docs.docker.com/compose/install/) by running the following, depending on your OS:
 ```
 # Fedora:
-sudo bash ./docker/scripts/install-docker-compose-fedora.sh
+sudo bash ./docker/scripts/install-docker compose-fedora.sh
 
 # CentOS 7 / RHEL 7:
-sudo bash ./docker/scripts/install-docker-compose-centos-rhel.sh
+sudo bash ./docker/scripts/install-docker compose-centos-rhel.sh
 ```
 
-If you ran the above script, then you can run *docker* and *docker-compose* without *sudo* if you log out and log in.
+If you ran the above script, then you can run *docker* and *docker compose* without *sudo* if you log out and log in.
 
 * Download docker images:
 ```
-docker-compose pull
+docker compose pull
 ```
 
 * Optionally, set up git pre-commit hook:
 ```
-docker-compose run --rm -e HOST_PWD=$PWD ceph /docker/ci/pre-commit-setup.sh
+docker compose run --rm -e HOST_PWD=$PWD ceph /docker/ci/pre-commit-setup.sh
 ```
 
 ## Usage
@@ -80,15 +80,15 @@ You don't need to build ceph if you've set ```CEPH_IMAGE=rhcsdashboard/ceph-rpm:
 
 ### Start ceph + dashboard feature services:
 ```
-docker-compose up -d
+docker compose up -d
 
 # Only ceph:
-docker-compose up -d ceph
+docker compose up -d ceph
 ```
 
 * Display ceph container logs:
 ```
-docker-compose logs -f ceph
+docker compose logs -f ceph
 ```
 
 * Access dashboard with credentials: admin / admin
@@ -106,17 +106,17 @@ http://127.0.0.1:$CEPH_PROXY_HOST_PORT
 
 * Restart dashboard module:
 ```
-docker-compose exec ceph /docker/restart-dashboard.sh
+docker compose exec ceph /docker/restart-dashboard.sh
 ```
 
 * Add OSD in 2nd host (once ceph dashboard is accessible):
 ```
-docker-compose up -d --scale ceph-host2=1
+docker compose --profile additional-host up -d
 ```
 
 * Stop all:
 ```
-docker-compose down
+docker compose down
 ```
 
 ### Build Ceph:
@@ -125,55 +125,55 @@ docker-compose down
 CEPH_IMAGE=rhcsdashboard/ceph:main  # DO NOT use ceph-rpm:... image.
 HOST_CCACHE_DIR=/path/to/your/local/.ccache
 
-docker-compose run --rm ceph /docker/build-ceph.sh
+docker compose run --rm ceph /docker/build-ceph.sh
 ```
 
 * Rebuild not proxied dashboard frontend:
 ```
-docker-compose run --rm ceph /docker/build-dashboard-frontend.sh
+docker compose run --rm ceph /docker/build-dashboard-frontend.sh
 ```
 
 ### Backend unit tests and/or lint:
 ```
 # All tests + lint:
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_tox
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_tox
 
 # Tests
 
 # All tests:
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_tox py3
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_tox py3
 # All tests in nautilus branch:
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_tox py3-cov,py27-cov
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_tox py3-cov,py27-cov
 
 # Only specific tests:
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_tox tests/test_rest_client.py tests/test_grafana.py
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_tox tests/test_rest_client.py tests/test_grafana.py
 
 # Only 1 test:
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_tox tests/test_rgw_client.py::RgwClientTest::test_ssl_verify
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_tox tests/test_rgw_client.py::RgwClientTest::test_ssl_verify
 
 # Run doctests in 1 file:
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_tox run -- pytest --doctest-modules tools.py
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_tox run -- pytest --doctest-modules tools.py
 
 # Lint
 
 # All files:
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_tox lint
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_tox lint
 # All files in nautilus branch:
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_tox py3-lint,py27-lint
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_tox py3-lint,py27-lint
 
 # Only 1 file:
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_tox lint controllers/health.py
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_tox lint controllers/health.py
 # Only 1 file in nautilus branch:
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_tox py3-run pylint controllers/health.py
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_tox py3-run pycodestyle controllers/health.py
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_tox py3-run pylint controllers/health.py
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_tox py3-run pycodestyle controllers/health.py
 
 # Other utilities
 
 # Check OpenAPI Specification:
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_tox openapi-check
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_tox openapi-check
 
 # List tox environmnets:
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_tox run tox -lv
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_tox run tox -lv
 ```
 
 * Check dashboard python code with **mypy**:
@@ -181,29 +181,29 @@ docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_tox run tox -lv
 # Enable mypy check in .env file:
 CHECK_MYPY=1
 
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_mypy
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_mypy
 
 # Only 1 file:
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_mypy src/pybind/mgr/dashboard/controllers/rgw.py
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_mypy src/pybind/mgr/dashboard/controllers/rgw.py
 ```
 
 * Run API tests (integration tests based on [Teuthology](https://github.com/ceph/teuthology)):
 ```
 # Run tests interactively:
-docker-compose run --rm -p 11000:11000 ceph bash
+docker compose run --rm -p 11000:11000 ceph bash
 source /docker/ci/sanity-checks.sh && create_api_tests_cluster
 run_teuthology_tests tasks.mgr.dashboard.test_health
 run_teuthology_tests {moreTests}
 cleanup_teuthology  # this also outputs coverage report.
 
 # All tests:
-docker-compose run --rm ceph /docker/ci/run-api-tests.sh
+docker compose run --rm ceph /docker/ci/run-api-tests.sh
 
 # Only specific tests:
-docker-compose run --rm ceph /docker/ci/run-api-tests.sh tasks.mgr.dashboard.test_health tasks.mgr.dashboard.test_pool
+docker compose run --rm ceph /docker/ci/run-api-tests.sh tasks.mgr.dashboard.test_health tasks.mgr.dashboard.test_pool
 
 # Only 1 test:
-docker-compose run --rm ceph /docker/ci/run-api-tests.sh tasks.mgr.dashboard.test_rgw.RgwBucketTest.test_all
+docker compose run --rm ceph /docker/ci/run-api-tests.sh tasks.mgr.dashboard.test_rgw.RgwBucketTest.test_all
 ```
 
 ### Frontend unit tests or lint:
@@ -211,52 +211,52 @@ docker-compose run --rm ceph /docker/ci/run-api-tests.sh tasks.mgr.dashboard.tes
 # Tests
 
 # All tests:
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_jest
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_jest
 
 # Only specific tests:
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_jest health.component.spec.ts
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_jest health.component.spec.ts
 
 # Only 1 test:
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_jest health.component.spec.ts -t "^HealthComponent should create$"
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_jest health.component.spec.ts -t "^HealthComponent should create$"
 
 # Lint
 
 # All files:
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_npm_lint
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_npm_lint
 ```
 
 ### Frontend E2E tests:
 ```
 # If ceph is running:
-docker-compose exec ceph /docker/ci/sanity-checks.sh run_frontend_e2e_tests
+docker compose exec ceph /docker/ci/sanity-checks.sh run_frontend_e2e_tests
 # Against a running nautilus cluster:
-docker-compose run --rm -e DASHBOARD_URL=https://ceph:11000 ceph-e2e
+docker compose run --rm -e DASHBOARD_URL=https://ceph:11000 ceph-e2e
 
 # Only 1 specific test file:
-docker-compose exec ceph /docker/ci/sanity-checks.sh run_frontend_e2e_tests --spec "cypress/integration/ui/dashboard.e2e-spec.ts"
+docker compose exec ceph /docker/ci/sanity-checks.sh run_frontend_e2e_tests --spec "cypress/integration/ui/dashboard.e2e-spec.ts"
 
 # If ceph is not running:
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_frontend_e2e_tests
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_frontend_e2e_tests
 ```
 
 ### Monitoring tests:
 ```
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_monitoring
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_monitoring
 ```
 
 ### Sanity checks:
 ```
-docker-compose run --rm ceph /docker/ci/run-sanity-checks.sh
+docker compose run --rm ceph /docker/ci/run-sanity-checks.sh
 ```
 
 ### Build Ceph documentation:
 ```
-docker-compose run --rm ceph /docker/ci/sanity-checks.sh run_build_doc
+docker compose run --rm ceph /docker/ci/sanity-checks.sh run_build_doc
 ```
 
 ### Display Ceph documentation:
 ```
-docker-compose run --rm -p 11001:8080 ceph /docker/ci/sanity-checks.sh run_serve_doc
+docker compose run --rm -p 11001:8080 ceph /docker/ci/sanity-checks.sh run_serve_doc
 
 # Access here: http://127.0.0.1:11001
 ```
@@ -280,7 +280,7 @@ will be used for authentication, so port 8080 must be available in your machine.
 
 * Start Keycloak:
 ```
-docker-compose up -d --scale keycloak=1 keycloak
+docker compose --profile sso up -d
 ```
 
 You can access Keycloak administration console with credentials: admin / keycloak
@@ -289,7 +289,7 @@ http://127.0.0.1:8080 or https://127.0.0.1:8443
 
 * Enable dashboard SSO in running ceph container:
 ```
-docker-compose exec ceph /docker/sso/sso-enable.sh
+docker compose exec ceph /docker/sso/sso-enable.sh
 ```
 
 * Access dashboard with SSO credentials: admin / ssoadmin
@@ -298,7 +298,7 @@ https://127.0.0.1:$CEPH_HOST_PORT
 
 * Disable dashboard SSO:
 ```
-docker-compose exec ceph /docker/sso/sso-disable.sh
+docker compose exec ceph /docker/sso/sso-disable.sh
 ```
 
 ## RGW Multi-Site
@@ -310,12 +310,12 @@ RGW_MULTISITE=1
 
 * Start ceph (cluster 1) + ceph2 (cluster 2):
 ```
-docker-compose up -d --scale ceph2=1 --scale prometheus2=1
+docker compose --profile ceph2 up -d
 ```
 
 * Run 100s duration [benchmark](https://github.com/markhpc/hsbench#usage):
 ```
-docker-compose exec ceph2 bash
+docker compose exec ceph2 bash
 hsbench -a <rgw-user-access-key> -s <rgw-user-secret-key> -u http://127.0.0.1:8000 -z 4K -d 100 -t 10 -b 10
 ```
 
@@ -328,7 +328,7 @@ DASHBOARD_URL=http://remote.ceph.cluster.com:8443
 
 * Start only ceph:
 ```
-docker-compose up -d ceph
+docker compose up -d ceph
 ```
 
 ## Build and push an image to docker registry:
@@ -395,10 +395,13 @@ docker push rhcsdashboard/ceph:main
 
 * Start ceph2 + ceph + ...:
 ```
-docker-compose up -d --scale ceph2=1 --scale prometheus2=1
+docker compose --profile ceph2 up -d
 
 # Start ceph2 but not ceph:
-docker-compose up -d --scale ceph2=1 --scale ceph=0
+docker compose --profile ceph2 up -d --scale ceph=0
+
+# Stop ceph2:
+docker compose --profile ceph2 down
 ```
 
 ## Start a downstream ceph product
@@ -411,7 +414,7 @@ DOWNSTREAM_BUILD=redhat
 
 and start the ceph normally.
 ```
-docker-compose up -d ceph
+docker compose up -d ceph
 ```
 
 ## Kafka + Kafka UI deployment
@@ -420,6 +423,6 @@ To start a Kafka and Kafka UI for testing rgw notification specifically,
 you can start the kafka and kafka-ui by
 
 ```
-docker-compose up -d kafka
+docker compose up -d kafka
 ```
 which will start both of them and kafka ui can be visible at http://localhost:8082

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
             - CYPRESS_CACHE_FOLDER=/ceph/build.cypress
             - DASHBOARD_DEV_SERVER=${DASHBOARD_DEV_SERVER:-1}
             - DASHBOARD_SSL=${DASHBOARD_SSL:-0}
+            - DASHBOARD_NPM_CI=${DASHBOARD_NPM_CI:-0}
             - DASHBOARD_URL
             - DOWNSTREAM_BUILD
             - TEST_ORCHESTRATOR

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.2'
-
 services:
     ceph-base:
         image: ${CEPH_IMAGE:-rhcsdashboard/ceph-rpm:main}
@@ -45,14 +43,13 @@ services:
         command: /docker/start.sh
         cpus: ${CEPH_CONTAINER_CPUS:-4}
         mem_limit: ${CEPH_CONTAINER_MEM_LIMIT:-6g}
-        scale: -1
+
     ceph:
         extends:
             service: ceph-base
         container_name: ceph
         hostname: ceph
         ports: ['${CEPH_PROXY_HOST_PORT:-4200}:4200','${CEPH_HOST_PORT:-11000}:11000']
-        scale: 1
 
     ceph-host2:
         extends:
@@ -60,6 +57,7 @@ services:
         container_name: ceph-host2
         hostname: ceph-host2
         command: /docker/start-ceph-additional-host.sh
+        profiles: ['additional-host']
 
     ceph2:
         extends:
@@ -71,6 +69,7 @@ services:
         volumes:
             - ${CEPH2_REPO_DIR}:/ceph
             - ${CEPH2_CUSTOM_BUILD_DIR:-empty_volume}:/ceph/build.custom
+        profiles: ['ceph2']
 
     ceph-e2e:
         extends:
@@ -83,6 +82,7 @@ services:
             - RUN_NPM_INSTALL=${RUN_NPM_INSTALL:-0}
         entrypoint: ''
         command: '/docker/e2e/e2e-run.sh'
+        profiles: ['e2e']
 
     ceph2-e2e:
         extends:
@@ -94,6 +94,7 @@ services:
             - ${CEPH2_REPO_DIR}:/ceph
         environment:
             - DASHBOARD_URL=${DASHBOARD_URL:-https://ceph2:11000}
+        profiles: ['ceph2-e2e']
 
     grafana:
         image: ${GRAFANA_IMAGE:-quay.io/ceph/ceph-grafana:9.4.7}
@@ -126,7 +127,7 @@ services:
         volumes:
             - ./docker/prometheus1:/etc/prometheus:Z
             - ${CEPH2_REPO_DIR}/${PROMETHEUS_ALERTS_DIR:-monitoring/ceph-mixin}:/etc/prometheus/alerts:Z
-        scale: -1
+        profiles: ['ceph2']
 
     node-exporter:
         image: ${NODE_EXPORTER_IMAGE:-prom/node-exporter:v1.5.0}
@@ -162,7 +163,7 @@ services:
             - KEYCLOAK_PASSWORD=keycloak
             - KEYCLOAK_IMPORT=/docker/saml-demo-realm.json
             - BIND=127.0.0.1
-        scale: -1
+        profiles: ['sso']
     
     haproxy:
         image: ${HAPROXY_IMAGE:-haproxy:2.3}
@@ -173,7 +174,7 @@ services:
             - ./docker/haproxy/haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg
             - ./docker/haproxy/dashboard.pem:/etc/ssl/certs/dashboard.pem
             - ./docker/haproxy/cors.lua:/etc/haproxy/cors.lua
-        scale: -1
+        profiles: ['haproxy']
 
     kafka:
         image: ${KAFKA_IMAGE:-confluentinc/cp-kafka:7.4.0}
@@ -193,6 +194,7 @@ services:
         - default
         depends_on:
             - kafka-ui
+        profiles: ['kafka']
 
     kafka-ui:
         image: ${KAFKA_UI_IMAGE:-provectuslabs/kafka-ui:latest}
@@ -203,6 +205,7 @@ services:
         ports: ['${KAFKA_UI_HOST_PORT:-8082}:8080']
         networks:
         - default
+        profiles: ['kafka']
 
 volumes:
     empty_volume:

--- a/docker/ceph/start-ceph.sh
+++ b/docker/ceph/start-ceph.sh
@@ -18,7 +18,11 @@ if [[ "$FRONTEND_BUILD_REQUIRED" == 1 ]]; then
         npm update @angular/cli
     fi
 
-    npm ci
+    if [[ "$DASHBOARD_NPM_CI" == 1 ]]; then
+        npm ci
+    else
+        npm install
+    fi
 
     if [[ -z "${DASHBOARD_URL}" && -z "${DOWNSTREAM_BUILD}" ]]; then
         # Required to run dashboard python module.

--- a/docker/scripts/install-docker-compose-fedora.sh
+++ b/docker/scripts/install-docker-compose-fedora.sh
@@ -10,37 +10,15 @@ fi
 
 dnf remove -y "docker*" || true
 
-dnf install -y dnf-plugins-core grubby
+dnf install -y dnf-plugins-core
+dnf-3 config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
 
-dnf info moby-engine >/dev/null 2>&1
-MOBY_ENGINE_EXISTS=$?
-if [[ ${MOBY_ENGINE_EXISTS} == 0 ]]; then
-    dnf install -y moby-engine
-else
-    dnf config-manager \
-        --add-repo \
-        https://download.docker.com/linux/fedora/docker-ce.repo
-
-#    dnf config-manager --set-disabled docker-ce-nightly
-#    dnf config-manager --set-disabled docker-ce-test
-
-    dnf install -y docker-ce
-fi
+dnf install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
 
 groupadd docker || true
 usermod -aG docker "$(logname)"
 
-FEDORA_VERSION=$(sed -nE 's/^VERSION_ID=(.*)$/\1/p' /etc/os-release)
-if [[ "${FEDORA_VERSION}" -eq 32 || "${FEDORA_VERSION}" -eq 33 ]]; then
-    # Docker does not yet cooperate with the nftables backend.
-    firewall-cmd --permanent --zone=trusted --add-interface=docker0 || true
-    firewall-cmd --permanent --zone=trusted --add-source=172.0.0.0/8 || true
-    firewall-cmd --reload
-elif [[ "${FEDORA_VERSION}" -ge 34 ]]; then
-      # Docker now cooperates with the nftables backend.
-      firewall-cmd --permanent --zone=docker --change-interface=docker0
-      firewall-cmd --reload
-fi
+systemctl enable --now firewalld
 
 # Run SELinux in permissive mode.
 setenforce 0
@@ -49,19 +27,4 @@ sed -i -E 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
 systemctl enable docker
 systemctl restart docker
 
-readonly dockerComposeVersion='1.21.0'
-
-curl -Ls "https://github.com/docker/compose/releases/download/$dockerComposeVersion/docker-compose-$(uname -s)-$(uname -m)" \
-    -o /usr/local/bin/docker-compose
-chmod +x /usr/local/bin/docker-compose
-
 echo "Docker successfully installed!!!"
-
-if [[ "${FEDORA_VERSION}" -ge 31 ]]; then
-    # Docker does not yet support Control Group V2.
-    grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=0"
-
-    echo "Please reboot in order for Cgroups backward compatibility to take effect."
-else
-    echo "Please log out and log in in order to use docker without 'sudo'."
-fi


### PR DESCRIPTION
older docker compose is obsolete now and doesn't work properly with newer OS. Things like `scale: -1` doesn't work anymore.

So adding `profiles` which makes it easier for starting and stopping some things. Updating the doc and also the script that install docker-compose