### PR TITLE
.github: build ceph-dev for arm64 arch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,15 +32,32 @@ jobs:
             centos_version: 9
     steps:
     - name: Checkout
-      uses: actions/checkout@master
-    - name: Build
-      run: docker build -t docker.io/rhcsdashboard/ceph-base:${{ matrix.os }} -f docker/ceph/centos/Dockerfile ./docker/ceph
-    - name: Push
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+    - name: Install QEMU for cross-arch emulation
       run: |
-        echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-        docker push docker.io/rhcsdashboard/ceph-base:${{ matrix.os }}
-        docker logout
+        sudo apt-get update
+        sudo apt-get install -y binfmt-support qemu-user-static
+    - name: Set up Docker Buildx
+      run: |
+        docker buildx create --name ceph_builder --use
+        docker buildx inspect ceph_builder --bootstrap
+    - name: Log in to DockerHub
+      run: |
+        echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+    - name: Build
+      run: |
+        docker buildx build \
+          --builder ceph_builder \
+          --platform linux/amd64,linux/arm64 \
+          --tag docker.io/rhcsdashboard/ceph-base:${{ matrix.os }} \
+          --push \
+          --file docker/ceph/centos/Dockerfile \
+          --build-arg CENTOS_VERSION=${{ matrix.centos_version }} \
+          ./docker/ceph
+    - name: Docker Logout
+      run: docker logout
   build-ceph:
+    name: build-${{ matrix.name }}-${{ matrix.arch }}-on-${{ matrix.branch }}
     needs: build-ceph-base
     runs-on: ubuntu-latest
     strategy:
@@ -48,22 +65,85 @@ jobs:
       matrix:
         branch: [main, tentacle, squid, reef, quincy, pacific]
         name: [ceph, ceph-rpm]
+        arch: [amd64, arm64]
         include:
           - centos_version: 9
           - name: ceph
             dir: ceph
           - name: ceph-rpm
             dir: ceph/rpm
+        exclude:
+          - name: ceph
+            arch: arm64
+          - branch: pacific
+            arch: arm64
+          - branch: quincy
+            arch: arm64
+          - branch: reef
+            arch: arm64
+          - branch: squid
+            arch: arm64
     steps:
     - name: Checkout
-      uses: actions/checkout@master
-    - name: Build
-      run: docker build -t docker.io/rhcsdashboard/${{ matrix.name }}:${{ matrix.branch }} -f docker/${{ matrix.dir }}/${{ matrix.branch_dir}}/Dockerfile ./docker/ceph --build-arg CEPH_RELEASE=${{ matrix.branch }} --build-arg VCS_BRANCH=${{ matrix.branch }} --build-arg CENTOS_VERSION=${{ matrix.centos_version }}
-    - name: Push
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
+    - name: Install QEMU for cross-arch emulation
       run: |
-        echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
-        docker push docker.io/rhcsdashboard/${{ matrix.name }}:${{ matrix.branch }}
-        docker logout
+        sudo apt-get update
+        sudo apt-get install -y binfmt-support qemu-user-static
+    - name: Set up Docker Buildx
+      run: |
+        docker buildx create --name ceph_builder --use
+        docker buildx inspect ceph_builder --bootstrap
+    - name: Log in to DockerHub
+      run: |
+        echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+    - name: Build arch-specific images
+      run: |
+        docker buildx build \
+          --platform linux/${{ matrix.arch }} \
+          --tag docker.io/rhcsdashboard/${{ matrix.name }}:${{ matrix.branch }}-${{ matrix.arch }} \
+          --push \
+          --file docker/${{ matrix.dir }}/${{ matrix.branch_dir }}/Dockerfile \
+          --build-arg CEPH_RELEASE=${{ matrix.branch }} \
+          --build-arg VCS_BRANCH=${{ matrix.branch }} \
+          --build-arg CENTOS_VERSION=${{ matrix.centos_version }} \
+          --provenance=false \
+          --sbom=false \
+          ./docker/ceph
+    - name: Docker Logout
+      run: docker logout
+
+  create-manifests:
+    needs: build-ceph
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [main, tentacle, squid, reef, quincy, pacific]
+        name: [ceph, ceph-rpm]
+    steps:
+    - name: Log in to DockerHub
+      run: |
+        echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+    - name: Create manifest and push
+      run: |
+        FINAL_TAG="docker.io/rhcsdashboard/${{ matrix.name }}:${{ matrix.branch }}"
+        AMD_TAG="${FINAL_TAG}-amd64"
+        ARM_TAG="${FINAL_TAG}-arm64"
+
+        echo "Creating manifest for $FINAL_TAG"
+        docker pull $AMD_TAG || true
+        docker pull $ARM_TAG || true
+
+        # check if arm tag exists before creating manifest
+        if docker manifest inspect $ARM_TAG > /dev/null 2>&1; then
+          docker manifest create $FINAL_TAG --amend $AMD_TAG --amend $ARM_TAG
+        else
+          docker manifest create $FINAL_TAG --amend $AMD_TAG
+        fi
+        docker manifest push $FINAL_TAG
+    - name: Docker Logout
+      run: docker logout
   build-ceph-e2e:
     runs-on: ubuntu-latest
     strategy:
@@ -80,3 +160,5 @@ jobs:
         echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
         docker push docker.io/rhcsdashboard/ceph-e2e:${{ matrix.branch }}
         docker logout
+    - name: Docker Logout
+      run: docker logout

--- a/docker/ceph/centos/Dockerfile
+++ b/docker/ceph/centos/Dockerfile
@@ -1,6 +1,12 @@
 ARG CENTOS_VERSION=9
+ARG TARGETPLATFORM
+ARG TARGETARCH
+
 FROM quay.io/centos/centos:stream$CENTOS_VERSION as ceph-base
+
+ARG TARGETARCH
 ARG CENTOS_VERSION
+ENV TARGETARCH=$TARGETARCH
 
 RUN dnf install -y epel-release \
     && dnf clean packages
@@ -31,9 +37,11 @@ RUN /root/aws-cli-configure.sh
 RUN pip3 install nodeenv
 
 # For dev. mode: run e2e tests.
-RUN dnf install -y https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm \
-    libXScrnSaver xorg-x11-server-Xvfb \
-    && dnf clean packages
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+    dnf install -y https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm \
+        libXScrnSaver xorg-x11-server-Xvfb \
+        && dnf clean packages; \
+    fi
 
 # SSO deps (install before fedora provisional deps).
 RUN dnf install -y gcc-c++ make \

--- a/docker/ceph/rpm/Dockerfile
+++ b/docker/ceph/rpm/Dockerfile
@@ -1,5 +1,11 @@
 ARG CENTOS_VERSION=9
+ARG TARGETPLATFORM
+ARG TARGETARCH
+
 FROM rhcsdashboard/ceph-base:centos_stream${CENTOS_VERSION}
+
+ARG TARGETARCH
+ENV TARGETARCH=$TARGETARCH
 ARG CENTOS_VERSION
 
 # Sepia provide missing dependencies until epel provide all dependencies.

--- a/docker/ceph/rpm/set-ceph-repo.sh
+++ b/docker/ceph/rpm/set-ceph-repo.sh
@@ -7,12 +7,22 @@ if [[ "${USE_REPO_FILES}" == 1 ]]; then
     exit 0
 fi
 
+echo "Setting target architecture for repo: $TARGETARCH"
+
+if [ "$TARGETARCH" = "amd64" ]; then
+    ARCH_NAME="x86_64"
+    ARCH_DIR="x86_64"
+else
+    ARCH_NAME="arm64"
+    ARCH_DIR="aarch64"
+fi
+
 if [[ -z "$REPO_URL" ]]; then
     if [[ -z "$CEPH_RELEASE" ]]; then
         CEPH_RELEASE=main
     fi
 
-    REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/$CENTOS_VERSION/x86_64&flavor=default&ref=$CEPH_RELEASE&sha1=latest" | jq -r '.[0] | .url')/x86_64/
+    REPO_URL=$(curl -s "https://shaman.ceph.com/api/search/?project=ceph&distros=centos/$CENTOS_VERSION/${ARCH_NAME}&flavor=default&ref=$CEPH_RELEASE&sha1=latest" | jq -r '.[0] | .url')/${ARCH_DIR}/
 fi
 
 echo "
@@ -23,7 +33,7 @@ enabled=1
 gpgcheck=0
 " > /etc/yum.repos.d/ceph.repo
 
-readonly REPO_URL_NOARCH=$(echo "$REPO_URL" | sed -e 's/x86_64/noarch/')
+readonly REPO_URL_NOARCH=$(echo "$REPO_URL" | sed -e "s/${ARCH_DIR}/noarch/")
 readonly REPO_URL_NOARCH_STATUS_CODE=$(curl -LIfs "$REPO_URL_NOARCH" | head -1 | awk '{print $2}')
 
 if [[ "$REPO_URL_NOARCH_STATUS_CODE" == 200 ]]; then


### PR DESCRIPTION
extend the docker build for arm64 as well.

for now, building arm64 images for main and tentacle branches only.