### PR TITLE
ceph-rpm/Dockerfile: fix dnf mirror links

### DIFF
--- a/docker/ceph/rpm/Dockerfile
+++ b/docker/ceph/rpm/Dockerfile
@@ -3,8 +3,8 @@ FROM rhcsdashboard/ceph-base:centos_stream${CENTOS_VERSION}
 ARG CENTOS_VERSION
 
 # Sepia provide missing dependencies until epel provide all dependencies.
-RUN dnf config-manager --add-repo http://apt-mirror.front.sepia.ceph.com/lab-extras/${CENTOS_VERSION}/
-RUN dnf config-manager --setopt gpgcheck=0 apt-mirror.front.sepia.ceph.com_lab-extras_${CENTOS_VERSION}_ --save
+RUN dnf config-manager --add-repo https://apt-mirror.sepia.ceph.com/lab-extras/${CENTOS_VERSION}/
+RUN dnf config-manager --setopt gpgcheck=0 apt-mirror.sepia.ceph.com_lab-extras_${CENTOS_VERSION}_ --save
 RUN dnf copr enable -y ceph/el${CENTOS_VERSION}
 
 ARG VCS_BRANCH=main


### PR DESCRIPTION
because https://github.com/ceph/ceph/pull/66656#issue-3736509760

`Publish ceph images` jobs were failing with
```
435.4 Error: Failed to download metadata for repo 'apt-mirror.front.sepia.ceph.com_lab-extras_9_': Cannot download repomd.xml: Cannot download repodata/repomd.xml: All mirrors were tried
435.4 + exit 1
```